### PR TITLE
Update Productivity,yaml and add Kape technologies

### DIFF
--- a/dataset/companies/Productivity.yaml
+++ b/dataset/companies/Productivity.yaml
@@ -54,3 +54,16 @@
   Description: ""
   Website: "https://bizzabo.com/"
   Alternatives: []
+- Name: "Kape Technologies, previously known as Crossrider"
+  Description: "UK-based company cofounded by an ex-Israeli surveillance agent and a billionaire previously convicted of insider trading who was later named in the Panama Papers. -Source: https://shorturl.at/eGW49 -Brands: ExpressVPN, Private Internet Access, CyberGhost VPN, ZenMate VPN, Intego Antivirus, Webselenese"
+  Website: "https://www.kape.com/"
+  Alternatives:
+  - Name: "Proton"
+    Description: "Proton Mail, VPN, Pass, Drive, has excellent free service"
+    Website: "https://proton.me/"
+  - Name: "IVPN"
+    Description: "VPN registered in Gibraltar"
+    Website: "https://www.ivpn.net/"
+  - Name: "MULLVAD"
+    Description: "VPN registered in Sweden"
+    Website: "https://mullvad.net"


### PR DESCRIPTION
Kape technologies previously known as Crossrider cofounded by an ex-Israeli surveillance agent and a billionaire previously convicted of insider trading who was later named in the Panama Papers. -Source: https://shorturl.at/eGW49 -Brands: ExpressVPN, Private Internet Access, CyberGhost VPN, ZenMate VPN, Intego Antivirus, Webselenese