### PR TITLE
Add large tech giants

### DIFF
--- a/dataset/companies/Developer.yaml
+++ b/dataset/companies/Developer.yaml
@@ -1,3 +1,21 @@
+- Name: "Microsoft"
+  Description: "Microsoft has offices on top of the destroyed Palestinian village Al-Haram"
+  Alternatives:
+  - Name: "Linux"
+    Description: "An open source alternative for Windows"
+    Website: "https://www.linux.org/"
+- Name: "Intel"
+  Description: "Intel has offices on the destroyed palestinian village Al-Haram"
+  Alternatives:
+  - Name: "AMD"
+    Description: "AMD also produces CPUs"
+    Website: "https://www.amd.com/"
+- Name: "Nvidia"
+  Description: "Nvidia has offices on the destroyed palestinian village Al-Shaykh Muwannis"
+  Alternatives:
+  - Name: "AMD"
+    Description: "AMD also produces GPUs"
+    Website: "https://www.amd.com/"
 - Name: "Wilco"
   Description: ""
   Website: "https://trywilco.com/"

--- a/dataset/companies/Developer.yaml
+++ b/dataset/companies/Developer.yaml
@@ -1,16 +1,19 @@
 - Name: "Microsoft"
+  Website: "www.microsoft.com"
   Description: "Microsoft has offices on top of the destroyed Palestinian village Al-Haram"
   Alternatives:
   - Name: "Linux"
     Description: "An open source alternative for Windows"
     Website: "https://www.linux.org/"
 - Name: "Intel"
+  Website: "www.intel.com"
   Description: "Intel has offices on the destroyed palestinian village Al-Haram"
   Alternatives:
   - Name: "AMD"
     Description: "AMD also produces CPUs"
     Website: "https://www.amd.com/"
 - Name: "Nvidia"
+  Website: "www.nvidia.com"
   Description: "Nvidia has offices on the destroyed palestinian village Al-Shaykh Muwannis"
   Alternatives:
   - Name: "AMD"

--- a/dataset/companies/Developer.yaml
+++ b/dataset/companies/Developer.yaml
@@ -1,19 +1,19 @@
 - Name: "Microsoft"
-  Website: "www.microsoft.com"
+  Website: "https://www.microsoft.com"
   Description: "Microsoft has offices on top of the destroyed Palestinian village Al-Haram"
   Alternatives:
   - Name: "Linux"
     Description: "An open source alternative for Windows"
     Website: "https://www.linux.org/"
 - Name: "Intel"
-  Website: "www.intel.com"
+  Website: "https://www.intel.com"
   Description: "Intel has offices on the destroyed palestinian village Al-Haram"
   Alternatives:
   - Name: "AMD"
     Description: "AMD also produces CPUs"
     Website: "https://www.amd.com/"
 - Name: "Nvidia"
-  Website: "www.nvidia.com"
+  Website: "https://www.nvidia.com"
   Description: "Nvidia has offices on the destroyed palestinian village Al-Shaykh Muwannis"
   Alternatives:
   - Name: "AMD"


### PR DESCRIPTION
Microsft, Intel and NVIDIA are all complicit in their support of the Zionist entity, and are actively participating in genocide against the palestinian people, and had built offices on the ruins of Palestinian cities and villages