### PR TITLE
Added new Reaction Exercise Tech company

### DIFF
--- a/dataset/companies/Others.yaml
+++ b/dataset/companies/Others.yaml
@@ -110,3 +110,13 @@
   Description: "Drone Delivery"
   Website: "https://flytrex.com/"
   Alternatives: []
+- Name: "Blazepod"
+  Description: "Smart Reaction Training Platform"
+  Website: "https://blazepod.co.il/"
+  Alternatives:
+    - Name: "CatchPad"
+      Description: "Interactive Exercise Platform"
+      Website: "https://catchpad.com/en/"
+    - Name: "Light Trainer"
+      Description: "Reaction Light Exercise System"
+      Website: "https://www.lighttrainer.net/"


### PR DESCRIPTION
Added the company "BlazePod" which is Founded and based in Tel Aviv, Israel.

Also added the alternatives "CatchPad" and "Light Trainer" which are Türkiye based companies producing an alternative Reaction Exercise Tech